### PR TITLE
fix: config setting DEVICE is not implemented and by default it start…

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -24,7 +24,7 @@ cfg = load_config()
 def get_sentence_transformer():
     model_folder_path = "models/sentence-transformers/all-MiniLM-L6-v2"
     # This will download the model to the given path and use it from there.
-    return HuggingFaceEmbeddings(cache_folder=model_folder_path)
+    return HuggingFaceEmbeddings(cache_folder=model_folder_path,model_kwargs={"device": cfg.DEVICE})
 
 
 # ->


### PR DESCRIPTION
config setting DEVICE is not implemented and by default, it starts CUDA on a machine with NVIDIA GPU and runs out of memory. This fix adds cfg.DEVICE to model_kwargs